### PR TITLE
Fix ResolutionFiniteGroup

### DIFF
--- a/lib/Resolutions/resFiniteGroup.gi
+++ b/lib/Resolutions/resFiniteGroup.gi
@@ -72,7 +72,7 @@ N:=Order(G);
 if IsMatrixGroup(G) then
 
 iso:=IsomorphismPermGroup(G);
-R:=ResolutionFiniteGroup(Image(iso),N);
+R:=ResolutionFiniteGroup(Image(iso),K);
 R!.elts:=List(R!.elts,x->PreImagesRepresentative(iso,x));
 R!.group:=G;
 return R;


### PR DESCRIPTION
It used to produce incorrect resolutions in some cases, see here:
 <https://github.com/gap-system/gap/issues/3056>

Of course it'd be better to also add a test for this bug, but for now I'd just be happy if this was fixed in a Hap release :-).

CC @alex-konovalov 