### PR TITLE
Add makedoc.g script

### DIFF
--- a/makedoc.g
+++ b/makedoc.g
@@ -1,0 +1,3 @@
+LoadPackage("HAP");
+MakeHAPManual();
+QUIT;

--- a/pdfdoc/README.md
+++ b/pdfdoc/README.md
@@ -1,0 +1,1 @@
+This directory is currently used by MakeHAPManual


### PR DESCRIPTION
This adds the makedoc.g script - the standard name and location required by ReleaseTools. See some current discussion in #1. 