### PR TITLE
Version 1.22

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -8,13 +8,21 @@ SetPackageInfo( rec(
 
   PackageName := "HAP",
   Subtitle  := "Homological Algebra Programming",
-  Version := "1.21",
+  Version := "1.22",
   Date    := "14/11/2019",
-  ArchiveURL 
-          := Concatenation( "http://hamilton.nuigalway.ie/Hap/hap", ~.Version ),
-  ArchiveFormats 
-          := ".tar.gz",
 
+  SourceRepository := rec(
+      Type := "git",
+      URL := Concatenation( "https://github.com/gap-packages/", LowercaseString(~.PackageName) ),
+  ),
+  IssueTrackerURL := Concatenation( ~.SourceRepository.URL, "/issues" ),
+  PackageWWWHome  := "http://hamilton.nuigalway.ie/Hap/www",
+  README_URL      := Concatenation( ~.PackageWWWHome, "/README.HAP" ),
+  PackageInfoURL  := Concatenation( ~.PackageWWWHome, "/PackageInfo.g" ),
+  ArchiveURL      := Concatenation( ~.SourceRepository.URL,
+                                   "/releases/download/v", ~.Version,
+                                   "/", LowercaseString(~.PackageName), "-", ~.Version ),
+  ArchiveFormats := ".tar.gz",
 
   Persons := [ 
     rec( 
@@ -41,13 +49,8 @@ SetPackageInfo( rec(
   AcceptDate 
           := "03/2006",
 
-  README_URL := "http://hamilton.nuigalway.ie/Hap/README.HAP",
-  PackageInfoURL := "http://hamilton.nuigalway.ie/Hap/PackageInfo.g",
-
   AbstractHTML := 
     "This package provides some functions for group cohomology. ",
-
-  PackageWWWHome := "http://hamilton.nuigalway.ie/Hap/www",
                   
   PackageDoc := rec(
     BookName  := "HAP",
@@ -96,8 +99,6 @@ AvailabilityTest := ReturnTrue,
 
 BannerString     := Concatenation( "Loading HAP ",
                             String( ~.Version ), " ...\n" ),
-
-Autoload := true,
 
 TestFile := "tst/testall.g",
 


### PR DESCRIPTION
Now, with the `makedoc.g` added in PR #11, ReleaseTools almost work. I did not use them to update the gh-pages branch, since that's another task, but I have published a release candidate at https://github.com/gap-packages/hap/releases/tag/v1.22 - @grahamknockillaree please download the tag.gz archive from there, it should have all documentation rebuilt for version 1.22. If it looks good to you, we can merge this branch, and then publish a proper release of 1.22. 

The changes in this PR update PackageInfo.g to reflect things that are now on GitHub (repository, issue tracker, release archives), while keeping the webpage of the package at the old location. It also deletes obsolete `Autoload` component.