### PR TITLE
Add stable-4.11 branch for Travis CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ addons:
 matrix:
   include:
     - env: GAPBRANCH=master
+    - env: GAPBRANCH=stable-4.11
     - env: GAPBRANCH=stable-4.10
     - env: GAPBRANCH=stable-4.9
     - env: GAPBRANCH=master ABI=32


### PR DESCRIPTION
@grahamknockillaree this adds tests in stable-4.11 branch to Travis CI, please merge it too (testing this PR will fail, since it currently fails in the master)