### PR TITLE
Don't call ObjectifyWithAttributes on a string

### DIFF
--- a/lib/CategoryTheory/categories.gi
+++ b/lib/CategoryTheory/categories.gi
@@ -10,7 +10,7 @@
 ## The category of groups. As the implementation improves the properties
 ## of this category will increase! 
 ##
-Category_Of_Groups:="Category_Of_Groups";
+Category_Of_Groups:=rec();
 HAP_type:= NewType(NewFamily("Category_Of_Groups"),
                        IsString  and 
                        HasInitialObject


### PR DESCRIPTION
Objectify and ObjectifyWithAttributes must only be called on records or plain
lists. Unfortunately this was not enforced uniformly by the GAP kernel, but in
future versions it may be.