### PR TITLE
Fix tst/testall.g and tst/testallextra.g

### DIFF
--- a/tst/testall.g
+++ b/tst/testall.g
@@ -1,12 +1,11 @@
 LoadPackage( "hap" );
 
-TestDirectory(DirectoriesPackageLibrary( "hap", "tst/testextra" ),
-  rec(exitGAP     := false,
-      testOptions := rec(compareFunction := "uptowhitespace") ) );
-
-TestDirectory(DirectoriesPackageLibrary( "hap", "tst/testall" ),
+dirs := Concatenation(
+            DirectoriesPackageLibrary( "hap", "tst/testextra" ),
+            DirectoriesPackageLibrary( "hap", "tst/testall" )
+        );
+TestDirectory(dirs,
   rec(exitGAP     := true,
       testOptions := rec(compareFunction := "uptowhitespace") ) );
-
 
 FORCE_QUIT_GAP(1); # if we ever get here, there was an error

--- a/tst/testallextra.g
+++ b/tst/testallextra.g
@@ -1,14 +1,11 @@
 LoadPackage( "hap" );
 
-TestDirectory(DirectoriesPackageLibrary( "hap", "tst/testextra" ),
-  rec(exitGAP     := false,
-      testOptions := rec(compareFunction := "uptowhitespace") ) );
-
-TestDirectory(DirectoriesPackageLibrary( "hap", "tst/testall" ),
-  rec(exitGAP     := false,
-      testOptions := rec(compareFunction := "uptowhitespace") ) );
-
-TestDirectory(DirectoriesPackageLibrary( "hap", "tst/testextraextra" ),
+dirs := Concatenation(
+            DirectoriesPackageLibrary( "hap", "tst/testextra" ),
+            DirectoriesPackageLibrary( "hap", "tst/testall" ),
+            DirectoriesPackageLibrary( "hap", "tst/testextraextra" )
+        );
+TestDirectory(dirs,
   rec(exitGAP     := true,
       testOptions := rec(compareFunction := "uptowhitespace") ) );
 


### PR DESCRIPTION
... to properly report test failures. Previously, any test failures in the
initial call(s) to TestDirectory did not lead to a non-zero exit code, and
hence also did not result in Travis CI properly detecting test failures.

We fix this by giving TestDirectory all directories with tests at once.