### PR TITLE
Add missing conversion (HAP -> hap) in the URL

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -16,7 +16,7 @@ SetPackageInfo( rec(
       URL := Concatenation( "https://github.com/gap-packages/", LowercaseString(~.PackageName) ),
   ),
   IssueTrackerURL := Concatenation( ~.SourceRepository.URL, "/issues" ),
-  PackageWWWHome  := Concatenation( "https://gap-packages.github.io/", ~.PackageName ),
+  PackageWWWHome  := Concatenation( "https://gap-packages.github.io/", LowercaseString(~.PackageName) ),
   README_URL      := Concatenation( ~.PackageWWWHome, "/README.md" ),
   PackageInfoURL  := Concatenation( ~.PackageWWWHome, "/PackageInfo.g" ),
   ArchiveURL      := Concatenation( ~.SourceRepository.URL,


### PR DESCRIPTION
@grahamknockillaree there is one missing conversion of the package name to lowercase, causing warnings from the package update system. Please merge this so it will be there when there will be a time for the next HAP release.