### PR TITLE
Correct use of TestDirectory

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -29,6 +29,7 @@ jobs:
           sudo apt-get install polymake singular
       - uses: gap-actions/setup-gap-for-packages@v1
         with:
+          GAP_PKGS_TO_CLONE: "polymaking" # We need >= 0.8.3 to support polymake 4.0
           GAP_PKGS_TO_BUILD: "io profiling nq"
           GAPBRANCH: ${{ matrix.gap-branch }}
       - uses: gap-actions/run-test-for-packages@v1
@@ -44,6 +45,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: gap-actions/setup-gap-for-packages@v1
         with:
+          GAP_PKGS_TO_CLONE: "polymaking" # We need >= 0.8.3 to support polymake 4.0
           GAP_PKGS_TO_BUILD: "io profiling nq"
       - uses: gap-actions/compile-documentation-for-packages@v1
         with:

--- a/tst/testall.g
+++ b/tst/testall.g
@@ -1,32 +1,17 @@
 LoadPackage( "hap" );
 
-TestDirectory(DirectoriesPackageLibrary( "hap", "tst/testall" ),
-  rec(exitGAP     := false,
-      testOptions := rec(compareFunction := "uptowhitespace") ) );
-
-
-TestDirectory(DirectoriesPackageLibrary( "hap", "tst/testall2" ),
-  rec(exitGAP     := false,
-      testOptions := rec(compareFunction := "uptowhitespace") ) );
-
-
-TestDirectory(DirectoriesPackageLibrary( "hap", "tst/testextra" ),
-  rec(exitGAP     := false,
-      testOptions := rec(compareFunction := "uptowhitespace") ) );
-
+dirs := Concatenation(
+  DirectoriesPackageLibrary( "hap", "tst/testall" ),
+  DirectoriesPackageLibrary( "hap", "tst/testall2" ),
+  DirectoriesPackageLibrary( "hap", "tst/testextra" ),
+  DirectoriesPackageLibrary( "hap", "tst/testextra2" )
+);
 
 if not GAPInfo.Architecture="x86_64-pc-linux-gnu-default32-kv8" then
-TestDirectory(DirectoriesPackageLibrary( "hap", "tst/testextra2" ),
-  rec(exitGAP     := false,
-      testOptions := rec(compareFunction := "uptowhitespace") ) );
-else
-TestDirectory(DirectoriesPackageLibrary( "hap", "tst/testextra2" ),
-  rec(exitGAP     := true,
-      testOptions := rec(compareFunction := "uptowhitespace") ) );
+    Append(dirs, DirectoriesPackageLibrary( "hap", "tst/testall3" ));
 fi;
 
-
-TestDirectory(DirectoriesPackageLibrary( "hap", "tst/testall3" ),
+TestDirectory(dirs,
   rec(exitGAP     := true,
       testOptions := rec(compareFunction := "uptowhitespace") ) );
 

--- a/tst/testallextra.g
+++ b/tst/testallextra.g
@@ -1,18 +1,13 @@
 LoadPackage( "hap" );
 
-TestDirectory(DirectoriesPackageLibrary( "hap", "tst/testextra" ),
-  rec(exitGAP     := false,
-      testOptions := rec(compareFunction := "uptowhitespace") ) );
+dirs := Concatenation(
+  DirectoriesPackageLibrary( "hap", "tst/testextra" ),
+  DirectoriesPackageLibrary( "hap", "tst/testall" ),
+  DirectoriesPackageLibrary( "hap", "tst/testall2" ),
+  DirectoriesPackageLibrary( "hap", "tst/testextraextra" )
+);
 
-TestDirectory(DirectoriesPackageLibrary( "hap", "tst/testall" ),
-  rec(exitGAP     := false,
-      testOptions := rec(compareFunction := "uptowhitespace") ) );
-
-TestDirectory(DirectoriesPackageLibrary( "hap", "tst/testall2" ),
-  rec(exitGAP     := false,
-      testOptions := rec(compareFunction := "uptowhitespace") ) );
-
-TestDirectory(DirectoriesPackageLibrary( "hap", "tst/testextraextra" ),
+TestDirectory(dirs,
   rec(exitGAP     := true,
       testOptions := rec(compareFunction := "uptowhitespace") ) );
 


### PR DESCRIPTION
The continuous integration setup requires that test failures are signaled by
the exit code of the GAP test scripts (i.e., tst/testall.g). This is what
`TestDirectory` normally ensures. But by calling it several times, only
allowing the final call to set a non-zero exit code, the results of all but
the final `TestDirectory` call are discarded.

To fix this, simply call `TestDirectory` once but with a list of all
directories to be processed.


This PR should cause the CI tests to fail per https://github.com/gap-packages/hap/pull/47#issuecomment-815122590