### PR TITLE
Fix IsHapQuotientElementRep declaration

### DIFF
--- a/lib/Objectifications/types.gd
+++ b/lib/Objectifications/types.gd
@@ -534,8 +534,7 @@ Print(R!.element, "_op ");
 DeclareCategory("IsHapQuotientElement",IsMultiplicativeElementWithInverse);
 
 DeclareRepresentation(  "IsHapQuotientElementRep",
-                        IsComponentObjectRep,
-                        IsMultiplicativeElementWithInverse,
+                        IsComponentObjectRep and IsMultiplicativeElementWithInverse,
                         ["oppositeElement",
                          ]);
 


### PR DESCRIPTION
The order of the 3rd and 4th argument was flipped. Which didn't matter, as both of them are ignored (and the 4th is even optional).

However, I am guessing you actually want `IsHapQuotientElementRep` to imply `IsMultiplicativeElementWithInverse`, so I changed it to do that. If that's not what you want, one can instead remove the line containing `IsMultiplicativeElementWithInverse,`