### PR TITLE
Make `StarGraph` an operation, with hidden attribute `StarGraphAttr`

### DIFF
--- a/lib/Polymake/aspherical.gi
+++ b/lib/Polymake/aspherical.gi
@@ -210,7 +210,8 @@ end);
 
 #####################################################################
 #####################################################################
-InstallMethod(StarGraph,
+InstallMethod(StarGraph, "For FPGroups", [IsFpGroup], StarGraphAttr);
+InstallMethod(StarGraphAttr,
 "For FpGroups",
 [IsFpGroup],
 function(G)

--- a/lib/hap.gd
+++ b/lib/hap.gd
@@ -359,7 +359,8 @@ DeclareGlobalFunction("ModPCohomologyGenerators");
 
 ## CURVATURE & POLYTOPES ############################################
 DeclareGlobalFunction("IsAspherical");
-DeclareAttribute("StarGraph",IsFpGroup);
+DeclareOperation("StarGraph",[IsFpGroup]);
+DeclareAttribute("StarGraphAttr",IsFpGroup);
 DeclareGlobalFunction("PolytopalGenerators");
 DeclareGlobalFunction("VectorStabilizer");
 DeclareGlobalFunction("PolytopalComplex");#doc


### PR DESCRIPTION
This resolves the clash with the operation `StarGraph` from the Digraphs package, which was introduced in Digraphs v1.5.0. https://github.com/digraphs/Digraphs/issues/514

The attribute `StarGraphAttr` now stores the computed value of the graph, which means that the graph does need to be recomputed for the same group. Moreover, it frees up the name `StarGraph` to be an operation, and to therefore be compatible with Digraphs. The overhead of the double method dispatch should be minimal.