### PR TITLE
Avoid syntax warning when loading without polymakeing

### DIFF
--- a/read.g
+++ b/read.g
@@ -96,8 +96,6 @@ fi;
 if IsPackageMarkedForLoading("polymaking","0.0") then
 ReadPackageHap( "lib/Polymake/convexCWspace.gi");
 ReadPackageHap( "lib/Polymake/fix.gi");
-else
-DeclareCategory("IsPolymakeObject",IsObject);
 fi;
 ################# POLYMAKING COMMANDS DONE #################################
 
@@ -289,7 +287,9 @@ ReadPackageHap( "lib/Polymake/aspherical.gi");
 ReadPackageHap( "lib/Polymake/polyGens.gi");
 ReadPackageHap( "lib/Polymake/stabilizer.gi");
 ReadPackageHap( "lib/Polymake/polyFaces.gi");
+if IsPackageMarkedForLoading("polymaking","0.0") then
 ReadPackageHap( "lib/Polymake/orbitPoly.gi");
+fi;
 #ReadPackageHap( "lib/Polymake/fix.gi");
 ReadPackageHap( "lib/Polymake/TZ.gi");
 


### PR DESCRIPTION
... e.g. by doing `LoadPackage("hap" : OnlyNeeded:=true);`

Also don't declare `IsPolymakeObject`, so that one can still
load polymaking later.

Resolves #68