### PR TITLE
Tweak how CrossedInvariant uses AllHomomorphisms

### DIFF
--- a/lib/CatGroups/CrossedInvariant.gi
+++ b/lib/CatGroups/CrossedInvariant.gi
@@ -3,7 +3,7 @@
 #################################################
 InstallGlobalFunction(CrossedInvariant,
 function(G,CC)
-local C, eta, pi1, pi2, homs, liftedhoms, delta, gensF, gensG, imgens, 
+local C, eta, pi1, pi2, iso, homs, liftedhoms, delta, gensF, gensG, imgens, 
 S,T, M, L, P, F, f, ff, r, m, x,g,Nf, Md, relsG, cnt, cnthom, cntrel, cntden,U;
 
 if not IsFpGroup(G) then 
@@ -33,11 +33,12 @@ eta:=NaturalHomomorphismByNormalSubgroup(P,Image(delta));
 pi1:=Target(eta);
 pi2:=HomotopyGroup(C,2);
 
-homs:=AllHomomorphisms(G,pi1);
+iso:=IsomorphismPermGroup(G);
+homs:=AllHomomorphisms(Image(iso),pi1);
 liftedhoms:=[];
 F:=FreeGroupOfFpGroup(G);
 gensF:=GeneratorsOfGroup(F);
-gensG:=GeneratorsOfGroup(G);
+gensG:=List(GeneratorsOfGroup(G), x -> Image(iso,x));
 relsG:=RelatorsOfFpGroup(G);
 cnt:=0;
 


### PR DESCRIPTION
Instead of invoking AllHomomorphisms on an fp-group, invoke it
on an isomorphic permutation group. This is faster. It also avoids
a problem with GAP 4.12 where AllHomomorphisms runs into an error
when invoked on a solvable fp group (that bug will be fixed there,
but in the meantime, it seems sensible to improve the HAP code, too)
