### PR TITLE
changed calls of SignRat to SignInt

### DIFF
--- a/lib/ArithmeticGroups/crystGcomplex.gi
+++ b/lib/ArithmeticGroups/crystGcomplex.gi
@@ -324,7 +324,7 @@ local i,x,k,combin,n,j,r,m,vect,c,
             Add(s,SolutionMat(B1,B2[i]));
         od;
         #Print(s);
-        return SignRat(Determinant(s));
+        return SignInt(Determinant(s));
     end;
     ###################################################################
     
@@ -531,7 +531,7 @@ local i,x,k,combin,n,j,r,m,vect,c,
                             DVFRec[k+1][ww[1]][ww[2]]:=[];
                             return DVFRec[k+1][ww[1]][ww[2]];
                         else 
-                            s:=SignRat(f[i]);
+                            s:=SignInt(f[i]);
                             f[i]:=f[i]-s*1/2;
                             x:=f*B;
                             y:=SearchOrbit(x,k+1);

--- a/lib/ArtinCoxeter/tuan/crystGcomplex.gi
+++ b/lib/ArtinCoxeter/tuan/crystGcomplex.gi
@@ -262,7 +262,7 @@ Add(s,SolutionMat(B1,B2[i]));
 od;
 #Print(s);
 
-return SignRat(Determinant(s));
+return SignInt(Determinant(s));
 end;
 #######################
 Boundary:=function(k,s)
@@ -391,7 +391,7 @@ for i in [1..n] do
     DVFRec[k+1][ww[1]][ww[2]]:=[];
     return DVFRec[k+1][ww[1]][ww[2]];
     else 
-	s:=SignRat(f[i]);
+	s:=SignInt(f[i]);
 	f[i]:=f[i]-s*1/2;
 	x:=f*B;
 	y:=SearchOrbit(x,k+1);


### PR DESCRIPTION
This relates to GAP issue #5191. 
The SignRat function in HAPcryst can be removed because SignInt works for rationals. 
Before this removal can be done it is necessary to change calls in HAP from SignRat to SignInt, hence this PR. 
Then, in due course, a Sign function can be added to the main library. 
(Difficult to check that these changes do not affect any tests because lots of tests fail for me anyway - should I expect this?) 