### PR TITLE
Fix bad entity in the tutorial again

### DIFF
--- a/tutorial/tutex/14.20.txt
+++ b/tutorial/tutex/14.20.txt
@@ -1,6 +1,6 @@
 gap> R:=ResolutionArtinGroup(D,8);
 Resolution of length 8 in characteristic 0 for &lt;fp group on the generators 
-[ f1, f2, f3, f4, f5, f6, f7 ]&gr; . 
+[ f1, f2, f3, f4, f5, f6, f7 ]&gt; . 
 No contracting homotopy available. 
 
 gap> Size(R);


### PR DESCRIPTION
This was originally fixed in https://github.com/gap-packages/hap/commit/b2a7b1cc5e41e3f42195a89095dbc774bb59b5d4 but was changed to the invalid form again in https://github.com/gap-packages/hap/commit/cfbc474f9ded4326f2f54ab84838a65f67b9fe4d.