### PR TITLE
compile.sh convenience

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -15,10 +15,10 @@ GACDIR=/usr/share/gap-4.12.0/;
 #####################################################################
 read version < version;
 
-LIB=$PKGDIR/Hap$version/lib;
+LIB=$PKGDIR/hap-$version/lib;
 
-rm $PKGDIR/Hap$version/boolean;
-echo "COMPILED:=true;" > $PKGDIR/Hap$version/boolean;
+rm $PKGDIR/hap-$version/boolean;
+echo "COMPILED:=true;" > $PKGDIR/hap-$version/boolean;
 
 #$GACDIR/gac -d $LIB/CompiledGAP/*.c;
 #mkdir  $LIB/CompiledGAP/Compiled;

--- a/compile.sh
+++ b/compile.sh
@@ -1,12 +1,12 @@
 #You must set PKGDIR equal to the directory in which GAP packages are stored
 # on your computer.
 
-PKGDIR=/home/graham/pkg;
+PKGDIR=$(dirname $(pwd));
 
 #You must set GACDIR equal to the directory in which the GAP compiler gac is
 #stored on your computer.
 
-GACDIR=/usr/share/gap-4.12.0/;
+GACDIR=$(dirname $(which gac))
 
 
 


### PR DESCRIPTION
It seems that the standard GAP package folder name is hap-1.53 rather than Hap1.53 and compile.sh is changed to reflect this.
The correct values of PKGDIR and GACDIR can be guessed and this is done in compile.sh.