### PR TITLE
Remove tutorial.tar from repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,5 +46,7 @@
 
 /pdfdoc/
 
+*.tar
+
 /gh-pages/
 /tmp/


### PR DESCRIPTION
Also add *.tar to .gitignore to reduce the likelihood of it being
added again by accident.
