### PR TITLE
Again: Don't call ObjectifyWithAttributes on a string

### DIFF
--- a/doc/Test.xml
+++ b/doc/Test.xml
@@ -1103,7 +1103,6 @@
 <C>HAP_PERMMOVES_DIM_2</C><Br/>
 <C>HAP_PERMMOVES_DIM_3</C><Br/>
 <C>HAP_XYXYXYXY</C><Br/>
-<C>HAP_type</C><Br/>
 <C>HAPchildFunctionToggle</C><Br/>
 <C>HAPchildToggle</C><Br/>
 <C>HAPchildren</C><Br/>

--- a/doc/Undocumented.xml
+++ b/doc/Undocumented.xml
@@ -6099,8 +6099,6 @@
 <Br/>
 <C>HAP_XYXYXYXY</C>&nbsp;&nbsp;&nbsp;&nbsp;<B>Examples:</B> <Br/>
 <Br/>
-<C>HAP_type</C>&nbsp;&nbsp;&nbsp;&nbsp;<B>Examples:</B> <Br/>
-<Br/>
 <C>HAPchildFunctionToggle</C>&nbsp;&nbsp;&nbsp;&nbsp;<B>Examples:</B> <Br/>
 <Br/>
 <C>HAPchildToggle</C>&nbsp;&nbsp;&nbsp;&nbsp;<B>Examples:</B> <Br/>

--- a/lib/CategoryTheory/categories.gi
+++ b/lib/CategoryTheory/categories.gi
@@ -10,13 +10,11 @@
 ## The category of groups. As the implementation improves the properties
 ## of this category will increase! 
 ##
-Category_Of_Groups:="Category_Of_Groups";
-HAP_type:= NewType(NewFamily("Category_Of_Groups"),
+BindGlobal("Category_Of_Groups", Objectify(
+           NewType(NewFamily("Category_Of_Groups"),
                        IsString  and 
                        HasInitialObject
-		       and HasTerminalObject);
-ObjectifyWithAttributes(Category_Of_Groups,HAP_type);
-MakeReadOnlyGlobal("Category_Of_Groups");
+		       and HasTerminalObject), []));
 
 
 #############################################################################

--- a/lib/CategoryTheory/categories.giworking
+++ b/lib/CategoryTheory/categories.giworking
@@ -10,13 +10,11 @@
 ## The category of groups. As the implementation improves the properties
 ## of this category will increase! 
 ##
-Category_Of_Groups:="Category_Of_Groups";
-HAP_type:= NewType(NewFamily("Category_Of_Groups"),
+BindGlobal("Category_Of_Groups", Objectify(
+           NewType(NewFamily("Category_Of_Groups"),
                        IsString  and 
                        HasInitialObject
-		       and HasTerminalObject);
-ObjectifyWithAttributes(Category_Of_Groups,HAP_type);
-MakeReadOnlyGlobal("Category_Of_Groups");
+		       and HasTerminalObject), []));
 
 
 #############################################################################

--- a/lib/hap_afterthought.gd
+++ b/lib/hap_afterthought.gd
@@ -16,7 +16,6 @@ fi;
 #MakeReadOnlyGlobal("HAP_PERMMOVES_DIM_2");
 #MakeReadOnlyGlobal("HAP_PERMMOVES_DIM_3");
 #MakeReadOnlyGlobal("HAP_XYXYXYXY");
-#MakeReadOnlyGlobal("HAP_type");
 #MakeReadOnlyGlobal("HAPchildFunctionToggle");
 #MakeReadOnlyGlobal("HAPchildToggle");
 #MakeReadOnlyGlobal("HAPchildren");


### PR DESCRIPTION
Objectify and ObjectifyWithAttributes must only be called on records or plain
lists. Unfortunately this was not enforced uniformly by the GAP kernel, but in
future versions it may be.

This patch was already merged in January 2020, but it was reverted (probably
by accident) in April 2020 (in a commit with title "Add directory Congruence,
plus related files", hence why I think this was an accident).
