### PR TITLE
define NC versions of PreImages... in init.g

### DIFF
--- a/init.g
+++ b/init.g
@@ -10,6 +10,20 @@ HapGlobalDeclarationsAreAlreadyLoaded:=true;
 MakeReadOnlyGlobal("HapGlobalDeclarationsAreAlreadyLoaded");
 fi;
 
+##I introduce the NC versions of PreImages...
+if not IsBound( PreImagesNC ) then
+    BindGlobal( "PreImagesNC", PreImages );
+fi;
+if not IsBound( PreImagesElmNC ) then
+    BindGlobal( "PreImagesElmNC", PreImagesElm );
+fi;
+if not IsBound( PreImagesSetNC ) then
+    BindGlobal( "PreImagesSetNC", PreImagesSet );
+fi;
+if not IsBound( PreImagesRepresentativeNC ) then
+    BindGlobal( "PreImagesRepresentativeNC", PreImagesRepresentative );
+fi;
+
 ReadPackage("HAP","/lib/externalSoftware.gap");
 
 


### PR DESCRIPTION
PreImages, PreImagesElm, PreImagesSet and PreImagesRepresentative, can all return incorrect results when the element(s) supplied are not in the range of the map.
This situation has been discussed in GAP issue #4809.
To rectify the situation the plan is to have NC versions of these four operations and to add tests to the non-NC versions.
The procedure to be adopted is as follows.
(1) Rename the four operations by adding 'NC' to their names, and then declare the original operations as synonyms of these. 
PR#5073 addresses this.
(2) Ask package authors/maintainers to convert all their methods for these functions to the NC versions (unless there is good reason not to do so).
A clause added to init.g ensures that the package still works in older versions of GAP.
(3) Once all the packages have been updated, add tests to the non-NC versions of the operations.

Progress with (2) has reached the stage where most packages which implement methods for one of these functions have merged a PR which does the conversion. (See, for example, PR#58 in the FR package.) 
Most of the remaining packages have a few calls to some of these functions in the library or test files, and there seems little need to ask their authors to make any changes at this stage. 
The situation with HAP is very different. The number of calls in the library to these four functions is 19, 4, 1 and 133 respectively. Once PR#5073 is merged, if the calls are not to NC versions then many tests will be performed, presumeably unnecessarily. 
This PR just makes the required changes to init.g. 
A further commit making a global change to the NC versions can be added, if requested, but the package authors may prefer to consider each of the 157 calls individually?
