### PR TITLE
Tweak CI and dependencies

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -30,9 +30,6 @@ jobs:
           - stable-4.14
           - stable-4.13
           - stable-4.12
-          - stable-4.11
-          - stable-4.10
-          - stable-4.9
 
     steps:
       - uses: actions/checkout@v6

--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -64,26 +64,21 @@ SetPackageInfo( rec(
 
 
   Dependencies := rec(
-    GAP := ">= 4.5.6",
+    GAP := ">= 4.12",
     NeededOtherPackages := [
                              [ "polycyclic", ">=1.1" ],
                              [ "crystcat",   ">=1.1" ],
                              [ "fga",        ">=1.1" ],
                              [ "aclib",      ">=1.1" ],
                              [ "nq",         ">=1.1" ],
-                            #[ "gapdoc",     ">=0.0" ],
                            ],
     SuggestedOtherPackages := [
-                              #[ "polycyclic", ">=1.1" ],
-                              #[ "aclib",      ">=1.1" ],
-                               [ "gapdoc",      ">=0.0" ],
-                              #[ "nq",         ">=1.1" ],
                                [ "homology",    ">=0.0"   ], 
                                [ "edim",      ">=1.2.2" ],
                                [ "singular", ">=06.07.23" ],
                                [ "congruence", ">=0,0" ],
-                               [ "HAPcryst", ">=0.0.0" ],
-                               [ "Polymaking", ">=0.8.3"],
+                               [ "HAPcryst", ">=0.1.0" ],
+                               [ "Polymaking", ">=0.8.4"],
                                [ "xmod", ">0.0" ],
                                [ "laguna", ">0.0"]
                               ],


### PR DESCRIPTION
CI failed in old GAP versions because polymaking is too hold for polymake 4;
sow we installed newer polymaking and hapcryst version to cope with that. But
the most recent version of hapcryst doesn't support old GAP versions anymore.
So just require GAP 4.12 here, too.

Also, cleanup some dependencies.
