### PR TITLE
Update return type of Singular's `hilb`

### DIFF
--- a/lib/HapPrime/gradedalgebra.gi
+++ b/lib/HapPrime/gradedalgebra.gi
@@ -1367,7 +1367,7 @@ if IsPackageMarkedForLoading("singular","0") then
         # Singular is using
         Ig := Ideal(R, GroebnerBasis(Ideal(R,I)));
         # Now get the Hilbert Series
-        series := SingularInterface("hilb", [Ig, 1, degs], "intvec");
+        series := SingularInterface("hilb", [Ig, 1, degs], "bigintvec");
     
         # Remove the last one element of the list since that is not part of
         # the series (see the Singular help)


### PR DESCRIPTION
This should fix the issues @fingolfin and I are experiencing in https://github.com/oscar-system/GAP.jl/pull/1305.

The CI in this project uses Singular v4.3.2p10 (cf. https://github.com/gap-packages/hap/actions/runs/20572930775/job/59083682726#step:3:234), which is from Oct 2023.
In more recent Singular versions (I think in https://github.com/Singular/Singular/commit/0632b1803ee9fc7d3c5a910a25ddcda105e42f87), the return type of `hilb` was changed from `intvec` to `bigintvec`.
Since the conversion from `intvec` to `bigintvec` is possible, we can just tell `SingularInterface` that the return type will be `bigintvec`. For new enough Singular versions, this just works, while for slightly older ones, there is an implicit conversion happening. 