### PR TITLE
Update return type of Singular's `hilb`, based on singular version

### DIFF
--- a/lib/HapPrime/gradedalgebra.gi
+++ b/lib/HapPrime/gradedalgebra.gi
@@ -1367,8 +1367,12 @@ if IsPackageMarkedForLoading("singular","0") then
         # Singular is using
         Ig := Ideal(R, GroebnerBasis(Ideal(R,I)));
         # Now get the Hilbert Series
-        series := SingularInterface("hilb", [Ig, 1, degs], "intvec");
-    
+        if SingularInterface("int", "system(\"version\")", "int") < 43211 then
+          series := SingularInterface("hilb", [Ig, 1, degs], "intvec");
+        else
+          series := SingularInterface("hilb", [Ig, 1, degs], "bigintvec");
+        fi;
+
         # Remove the last one element of the list since that is not part of
         # the series (see the Singular help)
         Remove(series, Length(series));


### PR DESCRIPTION
The same as https://github.com/gap-packages/hap/pull/142, but with a version guard to only apply the change to new enough singular versions.

cc @fingolfin @grahamknockillaree 