### PR TITLE
Update `PackageInfo.g` and CI suite

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -33,28 +33,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-      - name: 'Install additional dependencies'
-        run: |
-          sudo apt-get update
-          sudo apt-get install polymake singular graphviz
       - uses: gap-actions/setup-gap@v3
         with:
           gap-version: ${{ matrix.gap-version }}
-      - shell: bash
-        run: |
-          # Install GAP packages via PackageManager
-          gap -c 'LoadPackage("PackageManager");
-                    InstallPackage("polymaking");
-                    InstallPackage("hapcryst");
-                    InstallPackage("nq");
-                    InstallPackage("io");
-                    QUIT;'
-      - uses: gap-actions/build-pkg@v2
+      - uses: gap-actions/build-pkg@v3
       - uses: gap-actions/run-pkg-tests@v4
       #- uses: gap-actions/run-pkg-tests@v4
       #  with:
       #    mode: onlyneeded  # FIXME: disabled because the tests depend on too many optional packages
       - uses: gap-actions/process-coverage@v3
-      - uses: codecov/codecov-action@v5
+      - uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -83,6 +83,19 @@ SetPackageInfo( rec(
                                [ "xmod", ">0.0" ],
                                [ "laguna", ">0.0"]
                               ],
+    NeededSystemPackages := rec(
+                                 Ubuntu := [
+                                             [ "graphviz" ],
+                                             [ "imagemagick" ],
+                                             [ "singular" ],
+                                             [ "polymake" ]
+                                           ],
+                                 Homebrew := [
+                                               [ "graphviz" ],
+                                               [ "imagemagick" ],
+                                               [ "singular" ],
+                                             ]
+                               ),
 
     ExternalConditions := [["Some optional functions require Polymake software",
     "https://polymake.org/doku.php"],

--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -88,7 +88,7 @@ SetPackageInfo( rec(
                                              [ "graphviz" ],
                                              [ "imagemagick" ],
                                              [ "singular" ],
-                                             [ "polymake" ]
+                                             [ "polymake" ],
                                            ],
                                  Homebrew := [
                                                [ "graphviz" ],


### PR DESCRIPTION
This PR updates all actions used in the CI workflow to the latest version, and makes use of the new `Dependencies.NeededSystemPackages` field in `PackageInfo.g` to simplify the CI workflow(s).

Remarks:
 - The CI tests here don't seem to use `imagemagick`, but it is listed as a dependency in the package distribution? Perhaps because another package uses HAP's functionality for ImageMagick?